### PR TITLE
control number of dependencies to reduce compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ categories = ["command-line-utilities", "game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.39"
+anyhow = { version = "1.0.39", default-features = false }
 cargo-edit = "0.7.0"
 cargo-generate = "0.6.0"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-beta.2", default-features = false, features = [ "cargo", "std" ] }
 fs_extra = "1.2.0"
 kstring = "1.0.1"
-liquid = "0.22.0"
-liquid-core = "0.22.0"
-regex = "1.4.5"
-rust-ini = "0.16.1"
+liquid = { version = "0.22.0", default-features = false, features = [ "stdlib" ] }
+liquid-core = { version = "0.22.0", default-features = false }
+regex = { version = "1.4.5", default-features = false }
+rust-ini = { version = "0.16.1", default-features = false }
 strum = "0.20"
 strum_macros = "0.20"
 thiserror = "1.0.24"
@@ -33,5 +33,5 @@ walkdir = "2.3.2"
 assert_cmd = "1.0.3"
 cargo-edit = "0.7.0"
 nanoid = "0.3.0"
-predicates = "1.0.7"
+predicates = { version = "1.0.7", default-features = false }
 remove_dir_all = "0.7.0"


### PR DESCRIPTION
@Bromeon as per your suggestion, I have reduced the number of dependencies used by ftw. 

This is the dependency tree from main branch of ftw 
[ftw-main.txt](https://github.com/macalimlim/ftw/files/6216785/ftw-main.txt)
and this is the dependency tree from this branch
[ftw-control-deps.txt](https://github.com/macalimlim/ftw/files/6216786/ftw-control-deps.txt)

> The dependency tree might be different on windows...

I have noticed that the compile time was a little faster than before...
