### PR TITLE
Remove Build Dependency on game.gdnlib

### DIFF
--- a/src/ftw_command.rs
+++ b/src/ftw_command.rs
@@ -114,7 +114,6 @@ impl FtwCommand {
             "Makefile",
             "godot/default_env.tres",
             "godot/export_presets.cfg",
-            "godot/native/game.gdnlib",
             "godot/project.godot",
             "rust/src/lib.rs",
             "rust/Cargo.toml",


### PR DESCRIPTION
given that this is just a node in the game world, I'm not sure if this should be a hard requirement on building the game or not.  after all, within gdnative, you can pick and choose which classes you want to expose.