### PR TITLE
Fix: import gdnative prelude in lib.rs template

### DIFF
--- a/src/templates/lib_tmpl.rs
+++ b/src/templates/lib_tmpl.rs
@@ -3,7 +3,7 @@
 mod {{module}};
 {%- endfor %}
 
-use gdnative::prelude::{godot_init, InitHandle};
+use gdnative::prelude::*;
 
 // Function that registers all exposed classes to Godot
 fn init(handle: InitHandle) {


### PR DESCRIPTION
The default lib.rs template has a compiler error with newer versions of the gdnative library. Importing the Variant type is now required to run the godot_init macro. I decided to include the prelude instead of just importing Variant to hopefully prevent these API changes from breaking things in future versions.

# Test Plan:

```
ftw new test
cd test
ftw build
```


# Error Output:
```
error[E0433]: failed to resolve: use of undeclared type `Variant`
  --> rust\src\lib.rs:13:1
   |
13 | godot_init!(init);
   | ^^^^^^^^^^^^^^^^^ not found in this scope
   |
   = note: this error originates in the macro `$crate::godot_nativescript_init` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this struct
   |
4  | use gdnative::core_types::Variant;
   |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `example` due to 2 previous errors
 ERROR: The system cannot find the file specified. (os error 2)
Error: ()
```


# lib.rs

```
mod game;
mod spinning_cube;

use gdnative::prelude::{godot_init, InitHandle};

// Function that registers all exposed classes to Godot
fn init(handle: InitHandle) {
    handle.add_class::<game::Game>();
    handle.add_class::<spinning_cube::SpinningCube>();
}

// macros that create the entry-points of the dynamic library.
godot_init!(init);


```