### PR TITLE
Preliminary introduction of M1/M2 64-bit ARM MacOS build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ ftw build linux-x86_64 release # builds the library for the `linux-x86_64` pla
 - linux-x86
 - linux-x86_64
 - macos-x86_64
+- macos-aarch64
 - windows-x86-gnu
 - windows-x86-msvc
 - windows-x86

--- a/src/ftw_compiler.rs
+++ b/src/ftw_compiler.rs
@@ -80,6 +80,7 @@ impl Compiler for FtwCompiler {
                 cmd!(docker run ("-v") (volume_mount)
                      if (target == &FtwTarget::WindowsX86_64Gnu || target == &FtwTarget::WindowsX86_64Msvc) {("-e") ("C_INCLUDE_PATH=/usr/x86_64-w64-mingw32/include")}
                      if (target == &FtwTarget::MacOsX86_64) {("-e") ("CC=/opt/macosx-build-tools/cross-compiler/bin/x86_64-apple-darwin14-cc") ("-e") ("C_INCLUDE_PATH=/opt/macosx-build-tools/cross-compiler/SDK/MacOSX10.10.sdk/usr/include")}
+                     if (target == &FtwTarget::MacOsAarch64) {("-e") ("CC=/opt/macosx-build-tools/cross-compiler/bin/aarch64-apple-darwin14-cc") ("-e") ("C_INCLUDE_PATH=/opt/macosx-build-tools/cross-compiler/SDK/MacOSX10.10.sdk/usr/include")}
                      (DOCKER_IMAGE) ("/bin/bash") ("-c")
                      (cargo_build_cmd)).run()
             }

--- a/src/ftw_target.rs
+++ b/src/ftw_target.rs
@@ -16,6 +16,7 @@ pub enum FtwTarget {
     LinuxX86,
     LinuxX86_64,
     MacOsX86_64,
+    MacOsAarch64,
     WindowsX86Gnu,
     WindowsX86Msvc,
     WindowsX86_64Gnu,
@@ -61,7 +62,7 @@ impl FtwTarget {
     }
 
     fn is_macos(self) -> bool {
-        matches!(self, FtwTarget::MacOsX86_64)
+        matches!(self, FtwTarget::MacOsX86_64 | FtwTarget::MacOsAarch64)
     }
 }
 
@@ -76,6 +77,7 @@ impl ToCliArg for FtwTarget {
             FtwTarget::LinuxX86 => "i686-unknown-linux-gnu",
             FtwTarget::LinuxX86_64 => "x86_64-unknown-linux-gnu",
             FtwTarget::MacOsX86_64 => "x86_64-apple-darwin",
+            FtwTarget::MacOsAarch64 => "aarch64-apple-darwin",
             FtwTarget::WindowsX86Gnu => "i686-pc-windows-gnu",
             FtwTarget::WindowsX86Msvc => "i686-pc-windows-msvc",
             FtwTarget::WindowsX86_64Gnu => "x86_64-pc-windows-gnu",
@@ -152,6 +154,7 @@ impl FromStr for FtwTarget {
             "linux-x86" => Ok(FtwTarget::LinuxX86),
             "linux-x86_64" => Ok(FtwTarget::LinuxX86_64),
             "macos-x86_64" => Ok(FtwTarget::MacOsX86_64),
+            "macos-aarch64" => Ok(FtwTarget::MacOsAarch64),
             "windows-x86-gnu" => Ok(FtwTarget::WindowsX86Gnu),
             "windows-x86" | "windows-x86-msvc" => Ok(FtwTarget::WindowsX86Msvc),
             "windows-x86_64-gnu" => Ok(FtwTarget::WindowsX86_64Gnu),
@@ -184,6 +187,7 @@ mod ftw_target_tests {
             ("i686-unknown-linux-gnu", FtwTarget::LinuxX86),
             ("x86_64-unknown-linux-gnu", FtwTarget::LinuxX86_64),
             ("x86_64-apple-darwin", FtwTarget::MacOsX86_64),
+            ("aarch64-apple-darwin", FtwTarget::MacOsAarch64),
             ("i686-pc-windows-gnu", FtwTarget::WindowsX86Gnu),
             ("i686-pc-windows-msvc", FtwTarget::WindowsX86Msvc),
             ("x86_64-pc-windows-gnu", FtwTarget::WindowsX86_64Gnu),
@@ -205,6 +209,7 @@ mod ftw_target_tests {
             ("Linux/X11", FtwTarget::LinuxX86),
             ("Linux/X11", FtwTarget::LinuxX86_64),
             ("Mac OSX", FtwTarget::MacOsX86_64),
+            ("Mac OSX", FtwTarget::MacOsAarch64),
             ("Windows Desktop", FtwTarget::WindowsX86Gnu),
             ("Windows Desktop", FtwTarget::WindowsX86Msvc),
             ("Windows Desktop", FtwTarget::WindowsX86_64Gnu),
@@ -226,6 +231,7 @@ mod ftw_target_tests {
             ("", FtwTarget::LinuxX86),
             (".x86_64", FtwTarget::LinuxX86_64),
             (".zip", FtwTarget::MacOsX86_64),
+            (".zip", FtwTarget::MacOsAarch64),
             (".exe", FtwTarget::WindowsX86Gnu),
             (".exe", FtwTarget::WindowsX86Msvc),
             (".exe", FtwTarget::WindowsX86_64Gnu),
@@ -247,6 +253,7 @@ mod ftw_target_tests {
             ("so", FtwTarget::LinuxX86),
             ("so", FtwTarget::LinuxX86_64),
             ("dylib", FtwTarget::MacOsX86_64),
+            ("dylib", FtwTarget::MacOsAarch64),
             ("dll", FtwTarget::WindowsX86Gnu),
             ("dll", FtwTarget::WindowsX86Msvc),
             ("dll", FtwTarget::WindowsX86_64Gnu),
@@ -268,6 +275,7 @@ mod ftw_target_tests {
             ("lib", FtwTarget::LinuxX86),
             ("lib", FtwTarget::LinuxX86_64),
             ("lib", FtwTarget::MacOsX86_64),
+            ("lib", FtwTarget::MacOsAarch64),
             ("", FtwTarget::WindowsX86Gnu),
             ("", FtwTarget::WindowsX86Msvc),
             ("", FtwTarget::WindowsX86_64Gnu),
@@ -289,6 +297,7 @@ mod ftw_target_tests {
             ("linux-x86", FtwTarget::LinuxX86),
             ("linux-x86_64", FtwTarget::LinuxX86_64),
             ("macos-x86_64", FtwTarget::MacOsX86_64),
+            ("macos-aarch64", FtwTarget::MacOsAarch64),
             ("windows-x86-gnu", FtwTarget::WindowsX86Gnu),
             ("windows-x86", FtwTarget::WindowsX86Msvc),
             ("windows-x86-msvc", FtwTarget::WindowsX86Msvc),
@@ -313,6 +322,7 @@ mod ftw_target_tests {
             (FtwTarget::LinuxX86),
             (FtwTarget::LinuxX86_64),
             (FtwTarget::MacOsX86_64),
+            (FtwTarget::MacOsAarch64),
             (FtwTarget::WindowsX86Gnu),
             (FtwTarget::WindowsX86Msvc),
             (FtwTarget::WindowsX86Msvc),
@@ -345,6 +355,7 @@ mod ftw_target_tests {
             ("i686-unknown-linux-gnu", FtwTarget::LinuxX86),
             ("x86_64-unknown-linux-gnu", FtwTarget::LinuxX86_64),
             ("x86_64-apple-darwin", FtwTarget::MacOsX86_64),
+            ("aarch64-apple-darwin", FtwTarget::MacOsAarch64),
             ("i686-pc-windows-gnu", FtwTarget::WindowsX86Gnu),
             ("i686-pc-windows-msvc", FtwTarget::WindowsX86Msvc),
             ("x86_64-pc-windows-gnu", FtwTarget::WindowsX86_64Gnu),

--- a/src/util.rs
+++ b/src/util.rs
@@ -87,6 +87,7 @@ mod util_tests {
             assert_eq!("godot3-headless".to_string(), godot_exe);
         }
         let other_desktop_platforms = vec![
+            FtwTarget::MacOsAarch64,
             FtwTarget::MacOsX86_64,
             FtwTarget::WindowsX86Gnu,
             FtwTarget::WindowsX86Msvc,


### PR DESCRIPTION
Without these changes, one may only successfully invoke `ftw build` on a game project directory when working with MacOS machines with an Intel chipset. This will allow success with that command on newer ARM-based generations.